### PR TITLE
manifets -> manifest typo

### DIFF
--- a/documentation/modules/ROOT/pages/03-kustomize.adoc
+++ b/documentation/modules/ROOT/pages/03-kustomize.adoc
@@ -79,7 +79,7 @@ example are the `resources` and the `patchesJson6902` sections.
 
 > **NOTE** You can read about what options are availble for patching in the https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/[official documentaion site]
 
-Build this manifets by running:
+Build this manifest by running:
 
 [.console-input]
 [source,bash,subs="attributes+,+macros"]


### PR DESCRIPTION
There's a small typo in this tutorial, the word "manifets" should be "manifest"